### PR TITLE
Port forwarding for statsd and graphite

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 443, host: 8443
   config.vm.network :forwarded_port, guest: 8125, host: 8125, protocol: 'udp'
   config.vm.network :forwarded_port, guest: 8126, host: 8126
+  config.vm.network :forwarded_port, guest: 2003, host: 2003
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.


### PR DESCRIPTION
Forwarding ports 8125, 8126 and 2003 as part of the Vagrantfile will allow to send metrics to the virtual machine from the outside.
